### PR TITLE
Add Google login using Firebase

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,13 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TZ8644RH"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
-  <div class="max-w-4xl mx-auto bg-white p-6 rounded-lg shadow">
+  <div id="login-screen" class="max-w-sm mx-auto bg-white p-6 rounded-lg shadow text-center hidden">
+    <h2 class="text-xl font-bold mb-4">Sign in</h2>
+    <p class="mb-4">Please sign in with your Google account to continue.</p>
+    <button id="login-btn" onclick="login()" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Sign in with Google</button>
+  </div>
+
+  <div id="app" class="max-w-4xl mx-auto bg-white p-6 rounded-lg shadow hidden">
     <h1 class="text-2xl font-bold mb-4">DOI Validator & Audencia Rank Checker Tool</h1>
     <p class="text-sm text-gray-700 mb-4">
       Instructions: Paste your bibliography text here,—copied directly from a web page, a PDF, or a DOCX document into the box below. Then click “Validate” to check each reference for its DOI and Audencia journal rank. Line breaks and hyphens are handled automatically.
@@ -64,6 +70,6 @@
       Audencia Business School
     </a>
   </footer>
-  <script type="text/javascript" src="scripts/main.js"></script>
+  <script type="module" src="scripts/main.js"></script>
 </body>
 </html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,0 +1,43 @@
+// Initialize Firebase and enforce Google authentication before showing the app
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.11.0/firebase-app.js";
+import { getAuth, onAuthStateChanged, GoogleAuthProvider, signInWithPopup } from "https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js";
+
+const firebaseConfigFromHost = typeof __firebase_config !== 'undefined' ? __firebase_config : null;
+const firebaseConfig = firebaseConfigFromHost ? JSON.parse(firebaseConfigFromHost) : {
+    apiKey: "AIzaSyCsDIUOYmxLhvw_uL-lvYFu89AtfIfwhH0",
+    authDomain: "doichecker.firebaseapp.com",
+    projectId: "doichecker",
+    storageBucket: "doichecker.firebasestorage.app",
+    messagingSenderId: "798815713057",
+    appId: "1:798815713057:web:ffb823337b7acbfba27060",
+    measurementId: "G-8N4P8YW0WK"
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const provider = new GoogleAuthProvider();
+
+function showApp() {
+  document.getElementById('app').classList.remove('hidden');
+  document.getElementById('login-screen').classList.add('hidden');
+}
+
+function showLogin() {
+  document.getElementById('app').classList.add('hidden');
+  document.getElementById('login-screen').classList.remove('hidden');
+}
+
+onAuthStateChanged(auth, (user) => {
+  if (user) {
+    showApp();
+  } else {
+    showLogin();
+  }
+});
+
+export function login() {
+  signInWithPopup(auth, provider).catch((err) => console.error(err));
+}
+
+// expose login globally for inline onclick handler
+window.login = login;


### PR DESCRIPTION
## Summary
- require Google login with Firebase Auth before showing the tool
- add login screen and hide app until authentication
- implement login logic in `scripts/main.js`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68405bfc0efc832f9a1ee41e1e69bb8c